### PR TITLE
Stable time, closes #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports.handler = function () {
     request.get(config.base_url + config.replication_dir + 'state.txt')
         .then(parse.state)
         .then((data) => {
-            time = data.state;
+            time = data.state.timestamp;
             return new Promise(request.getGzipStream(data.changeUrl));
         })
         .then(parse.change)

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports.handler = function () {
         })
         .then(parse.change)
         .then((stats) => {
+            time = stats['_minute'];
             return new Promise(cwput.overallMetrics(stats, time));
         })
         .then((stats) => {

--- a/lib/cwput.js
+++ b/lib/cwput.js
@@ -7,17 +7,47 @@ const cw = new AWS.CloudWatch({
 
 module.exports = {
     overallMetrics: function (stats, time) {
+        time = time || +new Date();
+
         const overall = stats['_overall'];
         const data = [
-            {MetricName: 'nodes_created', Value: overall.cnode || 0},
-            {MetricName: 'nodes_modified', Value: overall.mnode || 0},
-            {MetricName: 'nodes_deleted', Value: overall.dnode || 0},
-            {MetricName: 'ways_created', Value: overall.cway || 0},
-            {MetricName: 'ways_modified', Value: overall.mway || 0},
-            {MetricName: 'ways_deleted', Value: overall.dway || 0},
-            {MetricName: 'relations_created', Value: overall.crelation || 0},
-            {MetricName: 'relations_modified', Value: overall.mrelation || 0},
-            {MetricName: 'relations_deleted', Value: overall.drelation || 0}
+            {
+                MetricName: 'nodes_created',
+                Value: overall.cnode || 0,
+                Timestamp: time
+            }, {
+                MetricName: 'nodes_modified',
+                Value: overall.mnode || 0,
+                Timestamp: time
+            }, {
+                MetricName: 'nodes_deleted',
+                Value: overall.dnode || 0,
+                Timestamp: time
+            }, {
+                MetricName: 'ways_created',
+                Value: overall.cway || 0,
+                Timestamp: time
+            }, {
+                MetricName: 'ways_modified',
+                Value: overall.mway || 0,
+                Timestamp: time
+            }, {
+                MetricName: 'ways_deleted',
+                Value: overall.dway || 0,
+                Timestamp: time
+            }, {
+                MetricName: 'relations_created',
+                Value: overall.crelation || 0,
+                Timestamp: time
+            }, {
+                MetricName: 'relations_modified',
+                Value: overall.mrelation || 0,
+                Timestamp: time
+            }, {
+                MetricName: 'relations_deleted',
+                Value: overall.drelation || 0,
+                Timestamp: time
+            }
         ];
 
         return new Promise((resolve, reject) => {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -44,6 +44,8 @@ module.exports = {
         // keyed by username
         // overall stats are simply a special username, '_overall'
 
+        let times = {};
+
         let action;
         let depth = 0;
 
@@ -54,6 +56,7 @@ module.exports = {
                 action = node.name[0];
             } else if (depth === 3) {
                 const user = node.attributes.user.split(',').join('.');
+
                 if (!stats[user]) stats[user] = {};
 
                 if (stats[user][action + node.name]) {
@@ -67,6 +70,10 @@ module.exports = {
                 } else {
                     stats['_overall'][action + node.name] = 1;
                 }
+
+                const minute = node.attributes.timestamp.slice(0, 16);
+                if (!times[minute]) times[minute] = 0;
+                times[minute] += 1;
             }
 
             // use other depths for refs and such in the future
@@ -80,6 +87,13 @@ module.exports = {
 
         return new Promise((resolve) => {
             parser.on('end', () => {
+                // find the dominant minute
+                stats['_minute'] = Object.keys(times).reduce((a, b) => {
+                    return times[a] > times[b] ? a : b;
+                });
+
+                stats['_minute'] = stats['_minute'] + ':00Z';
+
                 resolve(stats);
             });
         });


### PR DESCRIPTION
- Uses intrinsic timestamps rather than the current processing time when putting metrics.
- Makes it possible to backfill history without state files easily.
- We now have stable references for naming files on S3.