### PR TITLE
Dedupe queue

### DIFF
--- a/aggregator.js
+++ b/aggregator.js
@@ -53,9 +53,7 @@ function getMessage(context) {
         queue.receiveMessage({
             QueueUrl: context.queue,
             VisibilityTimeout: 10
-        }).then((err, data) => {
-            if (err) return reject(err);
-
+        }).then(data => {
             console.log('starting', data.Body);
             context.message = JSON.parse(data.Body);
             context.message.ReceiptHandle = data.ReceiptHandle;
@@ -68,7 +66,7 @@ function getMessage(context) {
             if (context.message.jobType === 'month') context.message.key = context.message.key.slice(0, 7);
 
             resolve(context);
-        });
+        }).catch(reject);
     });
 }
 
@@ -79,9 +77,7 @@ function deleteMessage(context) {
             ReceiptHandle: context.message.ReceiptHandle
         };
 
-        queue.deleteMessage(params, context.message.MD5OfBody).then((err, data) => {
-            if (err) return reject(err);
-
+        queue.deleteMessage(params, context.message.MD5OfBody).then(() => {
             delete context.message.data;
             delete context.message.children;
 
@@ -89,7 +85,7 @@ function deleteMessage(context) {
 
             delete context.message;
             resolve(context);
-        });
+        }).catch(reject);
     });
 }
 

--- a/aggregator.js
+++ b/aggregator.js
@@ -42,9 +42,9 @@ function getMessage(context) {
     return new Promise((resolve, reject) => {
         if (context.source) {
             if (context.source === 'perTenMinTrigger') {
-                context.queue = process.env.perTenMinQueue;
+                context.queue = process.env.slowQueue;
             } else {
-                context.queue = process.env.perMinQueue;
+                context.queue = process.env.fastQueue;
             }
         } else {
             return reject(new Error('missing source'));

--- a/cloudformation/osm-dash.template
+++ b/cloudformation/osm-dash.template
@@ -99,7 +99,7 @@
                             "Effect": "Allow",
                             "Resource": {
                                 "Fn::GetAtt": [
-                                    "perMinQueue",
+                                    "fastQueue",
                                     "Arn"
                                 ]
                             }
@@ -115,7 +115,7 @@
                             "Effect": "Allow",
                             "Resource": {
                                 "Fn::GetAtt": [
-                                    "perTenMinQueue",
+                                    "slowQueue",
                                     "Arn"
                                 ]
                             }
@@ -182,11 +182,11 @@
                         "MainTable": {
                             "Ref": "MainTable"
                         },
-                        "perMinQueue": {
-                            "Ref": "perMinQueue"
+                        "fastQueue": {
+                            "Ref": "fastQueue"
                         },
-                        "perTenMinQueue": {
-                            "Ref": "perTenMinQueue"
+                        "slowQueue": {
+                            "Ref": "slowQueue"
                         }
                     }
                 }
@@ -282,11 +282,11 @@
                         "MainTable": {
                             "Ref": "MainTable"
                         },
-                        "perMinQueue": {
-                            "Ref": "perMinQueue"
+                        "fastQueue": {
+                            "Ref": "fastQueue"
                         },
-                        "perTenMinQueue": {
-                            "Ref": "perTenMinQueue"
+                        "slowQueue": {
+                            "Ref": "slowQueue"
                         }
                     }
                 }
@@ -315,19 +315,15 @@
                 }
             }
         },
-        "perMinQueue": {
+        "fastQueue": {
             "Type": "AWS::SQS::Queue",
             "Properties": {
-                "ContentBasedDeduplication": true,
-                "FifoQueue": true,
                 "MessageRetentionPeriod": 1209600
             }
         },
-        "perTenMinQueue": {
+        "slowQueue": {
             "Type": "AWS::SQS::Queue",
             "Properties": {
-                "ContentBasedDeduplication": true,
-                "FifoQueue": true,
                 "MessageRetentionPeriod": 1209600
             }
         },

--- a/lib/overallCounts.js
+++ b/lib/overallCounts.js
@@ -25,23 +25,23 @@ function toCSV(obj) {
 }
 
 function mergeOverallCounts(context) {
-    const overallCounts = context.job.children.reduce((sum, count) => {
+    const overallCounts = context.message.children.reduce((sum, count) => {
         sum += zlib.gunzipSync(count.overallCounts.B).toString();
         return sum;
     }, '');
 
     // depending on the job type we might have to group stuff here.
 
-    if (!context.job.data) context.job.data = {};
-    context.job.data.overallCounts = overallCounts;
+    if (!context.message.data) context.message.data = {};
+    context.message.data.overallCounts = overallCounts;
     return context;
 }
 
 function packOverallCounts(context) {
     // pack values for dynamo
-    if (context.job.data.overallCounts) {
-        context.job.data.overallCounts = {
-            B: zlib.gzipSync(context.job.data.overallCounts)
+    if (context.message.data.overallCounts) {
+        context.message.data.overallCounts = {
+            B: zlib.gzipSync(context.message.data.overallCounts)
         };
     }
     return context;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -5,6 +5,7 @@ const AWS = require('aws-sdk');
 module.exports = {};
 module.exports.sendMessage = sendMessage;
 module.exports.receiveMessage = receiveMessage;
+module.exports.deleteMessage = deleteMessage;
 module.exports.minuteAggregation = minuteAggregation;
 
 function sendMessage(queue, body) {
@@ -28,9 +29,22 @@ function receiveMessage(params) {
     return new Promise((resolve, reject) => {
         sqs.receiveMessage(params, (err, data) => {
             if (err) return reject(err);
-            if (!data.Messages || data.Messages.length === 0) return reject(new Error('no messages in queue'));
+            if (!data.Messages || data.Messages.length === 0) {
+                return reject(new Error('no messages in queue'));
+            }
 
             resolve(data.Messages[0]);
+        });
+    });
+}
+
+function deleteMessage(params) {
+    const sqs = new AWS.SQS({region: process.env.AWS_REGION || 'us-west-2'});
+
+    return new Promise((resolve, reject) => {
+        sqs.deleteMessage(params, (err, data) => {
+            if (err) return reject(err);
+            resolve(data);
         });
     });
 }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -10,6 +10,7 @@ module.exports.receiveMessage = receiveMessage;
 module.exports.deleteMessage = deleteMessage;
 module.exports.minuteAggregation = minuteAggregation;
 module.exports.skipList = skipList;
+module.exports.hideMessageForFive = hideMessageForFive;
 
 function sendMessage(queue, body) {
     const sqs = new AWS.SQS({region: process.env.AWS_REGION || 'us-west-2'});
@@ -35,7 +36,9 @@ function receiveMessage(params) {
         }), (err, data) => {
             if (err) return reject(err);
             if (!data.Messages || data.Messages.length === 0) {
-                return reject(new Error('no messages in queue'));
+                const error = new Error('no messages in queue');
+                error.name = 'NoMoMessages';
+                return reject(error);
             }
 
             const message = data.Messages[0];
@@ -44,6 +47,8 @@ function receiveMessage(params) {
             const msgCreated = parseInt(message.Attributes.SentTimestamp);
             if ((message.MD5OfBody in skipList) &&
                 (msgCreated < skipList[message.MD5OfBody])) {
+
+                console.log('skipping', message.Body, 'completed it recently');
 
                 deleteMessage({
                     QueueUrl: params.QueueUrl,
@@ -66,8 +71,22 @@ function deleteMessage(params, MD5OfBody) {
     return new Promise((resolve, reject) => {
         sqs.deleteMessage(params, (err, data) => {
             if (err) return reject(err);
-
             addToSkipList(MD5OfBody);
+            resolve(data);
+        });
+    });
+}
+
+function hideMessageForFive(params) {
+    const sqs = new AWS.SQS({region: process.env.AWS_REGION || 'us-west-2'});
+
+    return new Promise((resolve, reject) => {
+        sqs.changeMessageVisibility({
+            QueueUrl: params.QueueUrl,
+            ReceiptHandle: params.ReceiptHandle,
+            VisibilityTimeout: 5 * 60
+        }, (err, data) => {
+            if (err) return reject(err);
             resolve(data);
         });
     });

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -3,10 +3,11 @@
 const AWS = require('aws-sdk');
 
 module.exports = {};
-module.exports.putMessage = putMessage;
+module.exports.sendMessage = sendMessage;
+module.exports.receiveMessage = receiveMessage;
 module.exports.minuteAggregation = minuteAggregation;
 
-function putMessage(queue, body) {
+function sendMessage(queue, body) {
     const sqs = new AWS.SQS({region: process.env.AWS_REGION || 'us-west-2'});
 
     return new Promise((resolve, reject) => {
@@ -21,6 +22,19 @@ function putMessage(queue, body) {
     });
 }
 
+function receiveMessage(params) {
+    const sqs = new AWS.SQS({region: process.env.AWS_REGION || 'us-west-2'});
+
+    return new Promise((resolve, reject) => {
+        sqs.receiveMessage(params, (err, data) => {
+            if (err) return reject(err);
+            if (!data.Messages || data.Messages.length === 0) return reject(new Error('no messages in queue'));
+
+            resolve(data.Messages[0]);
+        });
+    });
+}
+
 function minuteAggregation(keys, propogate) {
     const promises = [];
 
@@ -30,7 +44,7 @@ function minuteAggregation(keys, propogate) {
             jobType: 'minute',
             key: key.slice(0, 16)
         };
-        promises.push(putMessage(process.env.perMinQueue, message));
+        promises.push(sendMessage(process.env.perMinQueue, message));
     });
 
     if (propogate) {
@@ -51,7 +65,7 @@ function hourAggregation(keys) {
             jobType: 'hour',
             key: key.slice(0, 13)
         };
-        promises.push(putMessage(process.env.perMinQueue, message));
+        promises.push(sendMessage(process.env.perMinQueue, message));
     });
 
     return Promise.all(promises);
@@ -66,7 +80,7 @@ function dayAggregation(keys) {
             jobType: 'day',
             key: key.slice(0, 10)
         };
-        promises.push(putMessage(process.env.perTenMinQueue, message));
+        promises.push(sendMessage(process.env.perTenMinQueue, message));
     });
 
     return Promise.all(promises);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -45,8 +45,6 @@ function receiveMessage(params) {
             if ((message.MD5OfBody in skipList) &&
                 (msgCreated < skipList[message.MD5OfBody])) {
 
-                console.log('deleting dupe', message.MD5OfBody);
-
                 deleteMessage({
                     QueueUrl: params.QueueUrl,
                     ReceiptHandle: message.ReceiptHandle
@@ -69,7 +67,7 @@ function deleteMessage(params, MD5OfBody) {
         sqs.deleteMessage(params, (err, data) => {
             if (err) return reject(err);
 
-            if (!skipList[MD5OfBody]) addToSkipList(MD5OfBody);
+            addToSkipList(MD5OfBody);
             resolve(data);
         });
     });

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -79,7 +79,7 @@ function minuteAggregation(keys, propogate) {
             jobType: 'minute',
             key: key.slice(0, 16)
         };
-        promises.push(sendMessage(process.env.perMinQueue, message));
+        promises.push(sendMessage(process.env.fastQueue, message));
     });
 
     if (propogate) {
@@ -100,7 +100,7 @@ function hourAggregation(keys) {
             jobType: 'hour',
             key: key.slice(0, 13)
         };
-        promises.push(sendMessage(process.env.perMinQueue, message));
+        promises.push(sendMessage(process.env.fastQueue, message));
     });
 
     return Promise.all(promises);
@@ -115,7 +115,7 @@ function dayAggregation(keys) {
             jobType: 'day',
             key: key.slice(0, 10)
         };
-        promises.push(sendMessage(process.env.perTenMinQueue, message));
+        promises.push(sendMessage(process.env.slowQueue, message));
     });
 
     return Promise.all(promises);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -2,11 +2,14 @@
 
 const AWS = require('aws-sdk');
 
+const skipList = {};
+
 module.exports = {};
 module.exports.sendMessage = sendMessage;
 module.exports.receiveMessage = receiveMessage;
 module.exports.deleteMessage = deleteMessage;
 module.exports.minuteAggregation = minuteAggregation;
+module.exports.skipList = skipList;
 
 function sendMessage(queue, body) {
     const sqs = new AWS.SQS({region: process.env.AWS_REGION || 'us-west-2'});
@@ -14,8 +17,7 @@ function sendMessage(queue, body) {
     return new Promise((resolve, reject) => {
         sqs.sendMessage({
             QueueUrl: queue,
-            MessageBody: JSON.stringify(body),
-            MessageGroupId: body.jobType
+            MessageBody: JSON.stringify(body)
         }, (err, data) => {
             if (err) return reject(err);
             resolve(data);
@@ -27,23 +29,42 @@ function receiveMessage(params) {
     const sqs = new AWS.SQS({region: process.env.AWS_REGION || 'us-west-2'});
 
     return new Promise((resolve, reject) => {
-        sqs.receiveMessage(params, (err, data) => {
+        sqs.receiveMessage(Object.assign(params, {
+            AttributeNames: ['SentTimestamp'],
+            VisibilityTimeout: 10
+        }), (err, data) => {
             if (err) return reject(err);
             if (!data.Messages || data.Messages.length === 0) {
                 return reject(new Error('no messages in queue'));
             }
 
-            resolve(data.Messages[0]);
+            const message = data.Messages[0];
+
+            // skip and delete message if contents match one we've seen and processed recently
+            const msgCreated = parseInt(message.Attributes.SentTimestamp);
+            if ((message.MD5OfBody in skipList) &&
+                (msgCreated < skipList[message.MD5OfBody])) {
+                deleteMessage({
+                    QueueUrl: params.QueueUrl,
+                    ReceiptHandle: message.ReceiptHandle
+                }, message.MD5OfBody).then(() => {
+                    receiveMessage(params).then(resolve);
+                });
+            } else {
+                resolve(message);
+            }
         });
     });
 }
 
-function deleteMessage(params) {
+function deleteMessage(params, MD5OfBody) {
     const sqs = new AWS.SQS({region: process.env.AWS_REGION || 'us-west-2'});
 
     return new Promise((resolve, reject) => {
         sqs.deleteMessage(params, (err, data) => {
             if (err) return reject(err);
+
+            if (!skipList[MD5OfBody]) addToSkipList(MD5OfBody);
             resolve(data);
         });
     });
@@ -98,4 +119,10 @@ function dayAggregation(keys) {
     });
 
     return Promise.all(promises);
+}
+
+function addToSkipList(key, offset) {
+    if (offset === undefined) offset = 10 * 1000;
+    if (!key) throw new Error('invalid key');
+    skipList[key] = +new Date() + offset;
 }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -3,10 +3,10 @@
 const AWS = require('aws-sdk');
 
 module.exports = {};
-module.exports.generic = generic;
+module.exports.putMessage = putMessage;
 module.exports.minuteAggregation = minuteAggregation;
 
-function generic(queue, body) {
+function putMessage(queue, body) {
     const sqs = new AWS.SQS({region: process.env.AWS_REGION || 'us-west-2'});
 
     return new Promise((resolve, reject) => {
@@ -25,11 +25,12 @@ function minuteAggregation(keys, propogate) {
     const promises = [];
 
     keys.forEach(key => {
-        promises.push(generic(process.env.perMinQueue, {
+        const message = {
             worker: 'aggregator',
             jobType: 'minute',
             key: key.slice(0, 16)
-        }));
+        };
+        promises.push(putMessage(process.env.perMinQueue, message));
     });
 
     if (propogate) {
@@ -50,8 +51,7 @@ function hourAggregation(keys) {
             jobType: 'hour',
             key: key.slice(0, 13)
         };
-        const promise = generic(process.env.perMinQueue, message, 5);
-        promises.push(promise);
+        promises.push(putMessage(process.env.perMinQueue, message));
     });
 
     return Promise.all(promises);
@@ -61,11 +61,12 @@ function dayAggregation(keys) {
     const promises = [];
 
     keys.forEach(key => {
-        promises.push(generic(process.env.perTenMinQueue, {
+        const message = {
             worker: 'aggregator',
             jobType: 'day',
             key: key.slice(0, 10)
-        }));
+        };
+        promises.push(putMessage(process.env.perTenMinQueue, message));
     });
 
     return Promise.all(promises);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -44,11 +44,16 @@ function receiveMessage(params) {
             const msgCreated = parseInt(message.Attributes.SentTimestamp);
             if ((message.MD5OfBody in skipList) &&
                 (msgCreated < skipList[message.MD5OfBody])) {
+
+                console.log('deleting dupe', message.MD5OfBody);
+
                 deleteMessage({
                     QueueUrl: params.QueueUrl,
                     ReceiptHandle: message.ReceiptHandle
                 }, message.MD5OfBody).then(() => {
-                    receiveMessage(params).then(resolve);
+                    receiveMessage(params)
+                        .then(resolve)
+                        .catch(reject);
                 });
             } else {
                 resolve(message);

--- a/lib/userCounts.js
+++ b/lib/userCounts.js
@@ -28,23 +28,23 @@ function toCSV(obj) {
 }
 
 function mergeUserCounts(context) {
-    const userCounts = context.job.children.reduce((sum, count) => {
+    const userCounts = context.message.children.reduce((sum, count) => {
         sum += zlib.gunzipSync(count.userCounts.B).toString();
         return sum;
     }, '');
 
     // depending on the job type we might have to group stuff here.
 
-    if (!context.job.data) context.job.data = {};
-    context.job.data.userCounts = userCounts;
+    if (!context.message.data) context.message.data = {};
+    context.message.data.userCounts = userCounts;
     return context;
 }
 
 function packUserCounts(context) {
     // pack values for dynamo
-    if (context.job.data.userCounts) {
-        context.job.data.userCounts = {
-            B: zlib.gzipSync(context.job.data.userCounts)
+    if (context.message.data.userCounts) {
+        context.message.data.userCounts = {
+            B: zlib.gzipSync(context.message.data.userCounts)
         };
     }
     return context;

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -74,7 +74,10 @@ test('queue.getMessage no messages', t => {
 
 test('queue.deleteMessage', t => {
     queue.deleteMessage({QueueUrl: 'delete-message', ReceiptHandle: 'some-string'}, 'md5')
-        .then(t.ok)
+        .then(() => {
+            t.ok(true, 'message deleted');
+            t.true(queue.skipList.md5, 'message reminants listed in skipList');
+        })
         .catch(t.error)
         .then(t.end);
 });

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -32,6 +32,11 @@ AWS.mock('SQS', 'deleteMessage', (params, callback) => {
     callback(null, params);
 });
 
+AWS.mock('SQS', 'changeMessageVisibility', (params, callback) => {
+    console.log('changeMessageVisibility');
+    callback(null, params);
+});
+
 test('queue.sendMessage', t => {
     queue.sendMessage('idk', {'something': true})
         .then(result => {
@@ -77,6 +82,15 @@ test('queue.deleteMessage', t => {
         .then(() => {
             t.ok(true, 'message deleted');
             t.true(queue.skipList.md5, 'message reminants listed in skipList');
+        })
+        .catch(t.error)
+        .then(t.end);
+});
+
+test('queue.hideMessageForFive', t => {
+    queue.hideMessageForFive({QueueUrl: 'delete-message', ReceiptHandle: 'some-string'})
+        .then(() => {
+            t.ok(true, 'message hidden');
         })
         .catch(t.error)
         .then(t.end);

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -15,7 +15,10 @@ AWS.mock('SQS', 'receiveMessage', (params, callback) => {
                 MessageId: 'messageid-123',
                 ReceiptHandle: 'receiptHandle-123',
                 MD5OfBody: 'md5-123',
-                Body: '{"worker":"aggregator","jobType":"day","key":"2017-12-10"}'
+                Body: '{"worker":"aggregator","jobType":"day","key":"2017-12-10"}',
+                Attributes: {
+                    SentTimestamp: parseInt(+new Date() / 1000)
+                }
             }]
         });
     }
@@ -70,7 +73,7 @@ test('queue.getMessage no messages', t => {
 });
 
 test('queue.deleteMessage', t => {
-    queue.deleteMessage({QueueUrl: 'delete-message', ReceiptHandle: 'some-string'})
+    queue.deleteMessage({QueueUrl: 'delete-message', ReceiptHandle: 'some-string'}, 'md5')
         .then(t.ok)
         .catch(t.error)
         .then(t.end);

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -8,8 +8,8 @@ AWS.mock('SQS', 'sendMessage', (params, callback) => {
     callback(null, params);
 });
 
-test('queue.generic', t => {
-    queue.generic('idk', {'something': true})
+test('queue.putMessage', t => {
+    queue.putMessage('idk', {'something': true})
         .then(result => {
             t.equal(result.QueueUrl, 'idk', 'QueueUrl is set');
             t.equal(result.MessageBody, '{"something":true}', 'MessageBody is as expected');
@@ -19,7 +19,7 @@ test('queue.generic', t => {
 });
 
 test('catch error', t => {
-    queue.generic()
+    queue.putMessage()
         .then(t.error)
         .catch(err => {
             t.ok(err, 'surfaced error');

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -25,6 +25,10 @@ AWS.mock('SQS', 'receiveMessage', (params, callback) => {
     }
 });
 
+AWS.mock('SQS', 'deleteMessage', (params, callback) => {
+    callback(null, params);
+});
+
 test('queue.sendMessage', t => {
     queue.sendMessage('idk', {'something': true})
         .then(result => {
@@ -35,7 +39,7 @@ test('queue.sendMessage', t => {
         .catch(t.error);
 });
 
-test('catch error', t => {
+test('queue.sendMessage catch error', t => {
     queue.sendMessage()
         .then(t.error)
         .catch(err => {
@@ -62,5 +66,12 @@ test('queue.getMessage no messages', t => {
         .catch((err) => {
             t.ok(err, 'surfaced error');
         })
+        .then(t.end);
+});
+
+test('queue.deleteMessage', t => {
+    queue.deleteMessage({QueueUrl: 'delete-message', ReceiptHandle: 'some-string'})
+        .then(t.ok)
+        .catch(t.error)
         .then(t.end);
 });


### PR DESCRIPTION
- switches away from FIFO queues for more flexibility (5 min reduplication interval is too long)
- skips messages whose work has already been completed by other incoming messages
- fails more gracefully when children aren't ready yet
- rename perMinQueue to fastQueue
- rename perTenMinQueue to slowQueue